### PR TITLE
[fix] values of Fin in ascending order

### DIFF
--- a/src/Data/Finite.idr
+++ b/src/Data/Finite.idr
@@ -43,7 +43,7 @@ public export
   values {n = 0}   = [[]]
   values {n = S k} = [| values :: values |]
 
--- Denotationally equivalent to `Data.Fin.allFins`, but runs in linear, instead 
+-- Denotationally equivalent to `Data.Fin.allFins`, but runs in linear, instead
 -- of quadratic time. This is done by leveraging the runtime optimisation of
 -- natural-number shaped datatypes as described here:
 -- https://idris2.readthedocs.io/en/latest/reference/builtins.html

--- a/src/Data/Finite.idr
+++ b/src/Data/Finite.idr
@@ -43,14 +43,6 @@ public export
   values {n = 0}   = [[]]
   values {n = S k} = [| values :: values |]
 
-weaken : List (Fin k) -> List (Fin $ S k)
-weaken []        = []
-weaken (x :: xs) = weaken x :: weaken xs
-
-fins : {n : _} -> List (Fin n)
-fins {n = 0}   = []
-fins {n = S k} = last :: weaken (fins {n = k})
-
 public export %inline
 {n : _} -> Finite (Fin n) where
-  values = fins
+  values = allFins n

--- a/src/Data/Finite.idr
+++ b/src/Data/Finite.idr
@@ -43,15 +43,15 @@ public export
   values {n = 0}   = [[]]
   values {n = S k} = [| values :: values |]
 
-||| Denotationally equivalent to `Data.Fin.allFins`, but runs in linear,
-||| instead of quadratic time. This is done by leveraging the runtime
-||| optimisation of natural-number shaped datatypes as described here: 
-||| https://idris2.readthedocs.io/en/latest/reference/builtins.html
-||| Similar function also appears in `idris2-array` library in 
-||| `Data.Array.Index.allFinsFast`
-allFinsFast : (n : Nat) -> List (Fin n)
-allFinsFast 0 = []
-allFinsFast (S n) = go [] last
+-- Denotationally equivalent to `Data.Fin.allFins`, but runs in linear, instead 
+-- of quadratic time. This is done by leveraging the runtime optimisation of
+-- natural-number shaped datatypes as described here:
+-- https://idris2.readthedocs.io/en/latest/reference/builtins.html
+-- Similar function also appears in `Data.Array.Index.allFinsFast` in the
+-- `idris2-array` library.
+allFinsLinear : (n : Nat) -> List (Fin n)
+allFinsLinear 0 = []
+allFinsLinear (S n) = go [] last
   where
     go : List (Fin k) -> Fin k -> List (Fin k)
     go xs FZ     = FZ :: xs
@@ -59,4 +59,4 @@ allFinsFast (S n) = go [] last
 
 public export %inline
 {n : _} -> Finite (Fin n) where
-  values = allFinsFast n
+  values = allFinsLinear n

--- a/src/Data/Finite.idr
+++ b/src/Data/Finite.idr
@@ -43,6 +43,20 @@ public export
   values {n = 0}   = [[]]
   values {n = S k} = [| values :: values |]
 
+||| Denotationally equivalent to `Data.Fin.allFins`, but runs in linear,
+||| instead of quadratic time. This is done by leveraging the runtime
+||| optimisation of natural-number shaped datatypes as described here: 
+||| https://idris2.readthedocs.io/en/latest/reference/builtins.html
+||| Similar function also appears in `idris2-array` library in 
+||| `Data.Array.Index.allFinsFast`
+allFinsFast : (n : Nat) -> List (Fin n)
+allFinsFast 0 = []
+allFinsFast (S n) = go [] last
+  where
+    go : List (Fin k) -> Fin k -> List (Fin k)
+    go xs FZ     = FZ :: xs
+    go xs (FS x) = go (FS x :: xs) (assert_smaller (FS x) $ weaken x)
+
 public export %inline
 {n : _} -> Finite (Fin n) where
-  values = allFins n
+  values = allFinsFast n


### PR DESCRIPTION
The existing implementation of `values` for `Fin n` defines them using a custom function, in descending order. That is, values of `Fin 3` are specified to be `[2,1,0]`. 

This is not wrong, but it's counterintuitive, and incompatible with similar `base` functions such as `Data.Fin.List.allFins` and `Data.Vect.allFins` defining them in ascending order.

In this PR I used the already imported `allFins` to redefine the interface implementation of `Finite` for `Fin n`.